### PR TITLE
dpkg-reconfigure now requires a symlink

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/bash
 
-# Default to UTC if no TIMEZONE env variable is set
+# Default to UTC if no TZ env variable is set
 echo "Setting time zone to ${TZ=UTC}"
 # This only works on Debian-based images
-echo "${TZ}" > /etc/timezone
+ln -fs "/usr/share/zoneinfo/${TZ}" /etc/localtime
 dpkg-reconfigure tzdata
 
 # Replace this below with your own application start


### PR DESCRIPTION
Just writing the timezone to /etc/timezone doesn't seem to work anymore, you need to symlink the timezone to /etc/localtime.